### PR TITLE
Make menu bar look normal for smaller screens

### DIFF
--- a/src/app/elitefour/menu/menu.component.html
+++ b/src/app/elitefour/menu/menu.component.html
@@ -1,31 +1,43 @@
 <nav class="navbar navbar-expand navbar-dark m-0 p-0">
   <div class="collapse navbar-collapse content mx-auto">
-    <div class="list-group text-left">
-      <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}"
-         class="list-group-item list-group-item-action">
-        <div style="height: 40px;" class="w-100 d-flex align-items-center justify-content-center">
-          <i class="fas fa-list"></i>
+    <ul class="navbar-nav">
+      <li>
+        <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}"
+           class="list-group-item list-group-item-action">
+          <div style="height: 40px;" class="w-100 d-flex align-items-center justify-content-center">
+            <i class="fas fa-list"></i>
+          </div>
+        </a>
+      </li>
+      <li>
+        <a routerLink="help" routerLinkActive="active"
+           class="list-group-item list-group-item-action">
+          <div class="w-100 h-100 d-flex align-items-center justify-content-center">
+            <i class="fas fa-question"></i>
+          </div>
+        </a>
+      </li>
+      <li>
+        <a class="list-group-item list-group-item-action" (click)="export()">
+          <div class="w-100 h-100 d-flex align-items-center justify-content-center">
+            <i class="fas fa-download"></i>
+          </div>
+        </a>
+      </li>
+      <li>
+        <a class="list-group-item list-group-item-action" (click)="import()">
+          <div class="w-100 h-100 d-flex align-items-center justify-content-center">
+            <i class="fas fa-upload"></i>
+          </div>
+        </a>
+      </li>
+    </ul>
+    <ul class="navbar-nav ml-auto">
+      <li>
+        <div class="list-group navbar-nav ml-auto text-right">
+          <span class="text-right version">v{{version}}</span>
         </div>
-      </a>
-      <a routerLink="help" routerLinkActive="active"
-         class="list-group-item list-group-item-action">
-        <div class="w-100 h-100 d-flex align-items-center justify-content-center">
-          <i class="fas fa-question"></i>
-        </div>
-      </a>
-      <a class="list-group-item list-group-item-action" (click)="export()">
-        <div class="w-100 h-100 d-flex align-items-center justify-content-center">
-          <i class="fas fa-download"></i>
-        </div>
-      </a>
-      <a class="list-group-item list-group-item-action" (click)="import()">
-        <div class="w-100 h-100 d-flex align-items-center justify-content-center">
-          <i class="fas fa-upload"></i>
-        </div>
-      </a>
-    </div>
-    <div class="list-group text-right">
-      <span class="text-right version">Version {{version}}</span>
-    </div>
+      </li>
+    </ul>
   </div>
 </nav>

--- a/src/environments/version.ts
+++ b/src/environments/version.ts
@@ -1,3 +1,3 @@
 // This file is updated when the product is built for production. If you change the structure of this file, make sure to change
 // build-for-gh-pages.sh as well!
-export const VERSION = 'development';
+export const VERSION = 'd.e.v';


### PR DESCRIPTION
The version always took half the menu bar, which makes the other options overflow when viewing on small screens. This is fixed in this pull request.

Also, the default version is now set to "d.e.v", (could also have chosen 0.0.0), to make the width equally large.